### PR TITLE
Moved VKs to their corresponding locations

### DIFF
--- a/KBFRZ71.klc
+++ b/KBFRZ71.klc
@@ -39,7 +39,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 0a	9		0	00ab	9	-1	-1	201c	2039		// « 9   “ ‹ 
 0b	0		0	00bb	0	-1	-1	201d	203a		// » 0   ” › 
 0c	OEM_4		0	0027	0022	-1	-1	00b0	02da@		// ' "   ° ˚ 
-0d	OEM_PLUS	0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
+0d	OEM_6		0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
 10	A		5	a	A	-1	-1	00e6	00c6		// a A   æ Æ
 11	Z		1	z	Z	-1	-1	00a3	-1		// z Z   £   
 12	E		1	e	E	-1	-1	20ac	0000@		// e E   €   
@@ -49,8 +49,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 16	U		5	u	U	-1	-1	00f9	00d9		// u U   ù Ù 
 18	O		5	o	O	-1	-1	0153	0152		// o O   œ Œ 
 19	P		1	p	P	-1	-1	0025	2030		// p P   % ‰ 
-1a	OEM_6		0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
-1b	OEM_1		0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
+1a	OEM_MINUS	0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
+1b	OEM_PLUS	0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
 1e	Q		5	q	Q	-1	-1	03b8	0398		// q Q   θ Θ  
 1f	S		5	s	S	-1	-1	00df	1e9e		// s S   ß ẞ
 20	D		1	d	D	-1	-1	0024	-1		// d D   $   
@@ -69,8 +69,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 2f	V		1	v	V	-1	-1	00b8@	02db@		// v V   ¸ ˛ 
 30	B		1	b	B	-1	-1	002d@	-1		// b B     
 31	N		1	n	N	-1	-1	007e@	-1		// n N   ~   
-32	OEM_COMMA	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
-33	OEM_PERIOD	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
+32	OEM_PERIOD	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
+33	OEM_COMMA	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	202f	00a0		//         

--- a/KBFRZ71.klc.tpl
+++ b/KBFRZ71.klc.tpl
@@ -39,7 +39,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 0a	9		0	00ab	9	-1	-1	201c	2039		// « 9   “ ‹ 
 0b	0		0	00bb	0	-1	-1	201d	203a		// » 0   ” › 
 0c	OEM_4		0	0027	0022	-1	-1	00b0	02da@		// ' "   ° ˚ 
-0d	OEM_PLUS	0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
+0d	OEM_6		0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
 10	A		5	a	A	-1	-1	00e6	00c6		// a A   æ Æ
 11	Z		1	z	Z	-1	-1	00a3	-1		// z Z   £   
 12	E		1	e	E	-1	-1	20ac	0000@		// e E   €   
@@ -49,8 +49,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 16	U		5	u	U	-1	-1	00f9	00d9		// u U   ù Ù 
 18	O		5	o	O	-1	-1	0153	0152		// o O   œ Œ 
 19	P		1	p	P	-1	-1	0025	2030		// p P   % ‰ 
-1a	OEM_6		0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
-1b	OEM_1		0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
+1a	OEM_MINUS	0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
+1b	OEM_PLUS	0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
 1e	Q		5	q	Q	-1	-1	03b8	0398		// q Q   θ Θ  
 1f	S		5	s	S	-1	-1	00df	1e9e		// s S   ß ẞ
 20	D		1	d	D	-1	-1	0024	-1		// d D   $   
@@ -69,8 +69,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 2f	V		1	v	V	-1	-1	00b8@	02db@		// v V   ¸ ˛ 
 30	B		1	b	B	-1	-1	002d@	-1		// b B     
 31	N		1	n	N	-1	-1	007e@	-1		// n N   ~   
-32	OEM_COMMA	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
-33	OEM_PERIOD	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
+32	OEM_PERIOD	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
+33	OEM_COMMA	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	202f	00a0		//         

--- a/KBFRZ71N.klc
+++ b/KBFRZ71N.klc
@@ -45,7 +45,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 0b	0		SGCap	00bb	0	-1	-1	201d	203a		// » 0   ” › 
 -1	-1		0	0	00bb						// 0 »
 0c	OEM_4		0	0027	0022	-1	-1	00b0	02da@		// ' "   ° ˚ 
-0d	OEM_PLUS	0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
+0d	OEM_6		0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
 10	A		5	a	A	-1	-1	00e6	00c6		// a A   æ Æ
 11	Z		1	z	Z	-1	-1	00a3	-1		// z Z   £   
 12	E		1	e	E	-1	-1	20ac	0000@		// e E   €   
@@ -55,8 +55,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 16	U		5	u	U	-1	-1	00f9	00d9		// u U   ù Ù 
 18	O		5	o	O	-1	-1	0153	0152		// o O   œ Œ 
 19	P		1	p	P	-1	-1	0025	2030		// p P   % ‰ 
-1a	OEM_6		0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
-1b	OEM_1		0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
+1a	OEM_MINUS	0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
+1b	OEM_PLUS	0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
 1e	Q		5	q	Q	-1	-1	03b8	0398		// q Q   θ Θ  
 1f	S		5	s	S	-1	-1	00df	1e9e		// s S   ß ẞ
 20	D		1	d	D	-1	-1	0024	-1		// d D   $   
@@ -75,8 +75,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 2f	V		1	v	V	-1	-1	00b8@	02db@		// v V   ¸ ˛ 
 30	B		1	b	B	-1	-1	002d@	-1		// b B     
 31	N		1	n	N	-1	-1	007e@	-1		// n N   ~   
-32	OEM_COMMA	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
-33	OEM_PERIOD	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
+32	OEM_PERIOD	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
+33	OEM_COMMA	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	202f	00a0		//         

--- a/KBFRZ71N.klc.tpl
+++ b/KBFRZ71N.klc.tpl
@@ -45,7 +45,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 0b	0		SGCap	00bb	0	-1	-1	201d	203a		// » 0   ” › 
 -1	-1		0	0	00bb						// 0 »
 0c	OEM_4		0	0027	0022	-1	-1	00b0	02da@		// ' "   ° ˚ 
-0d	OEM_PLUS	0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
+0d	OEM_6		0	005e@	00a8@	-1	001e	02c7@	-1		// ^ ¨   ˇ   
 10	A		5	a	A	-1	-1	00e6	00c6		// a A   æ Æ
 11	Z		1	z	Z	-1	-1	00a3	-1		// z Z   £   
 12	E		1	e	E	-1	-1	20ac	0000@		// e E   €   
@@ -55,8 +55,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 16	U		5	u	U	-1	-1	00f9	00d9		// u U   ù Ù 
 18	O		5	o	O	-1	-1	0153	0152		// o O   œ Œ 
 19	P		1	p	P	-1	-1	0025	2030		// p P   % ‰ 
-1a	OEM_6		0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
-1b	OEM_1		0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
+1a	OEM_MINUS	0	002d	2013	-1	-1	2212	2011		// - –   − ‑ 
+1b	OEM_PLUS	0	002b	00b1	-1	-1	2020	2021		// + ±   † ‡ 
 1e	Q		5	q	Q	-1	-1	03b8	0398		// q Q   θ Θ  
 1f	S		5	s	S	-1	-1	00df	1e9e		// s S   ß ẞ
 20	D		1	d	D	-1	-1	0024	-1		// d D   $   
@@ -75,8 +75,8 @@ LAYOUT		;an extra '@' at the end is a dead key
 2f	V		1	v	V	-1	-1	00b8@	02db@		// v V   ¸ ˛ 
 30	B		1	b	B	-1	-1	002d@	-1		// b B     
 31	N		1	n	N	-1	-1	007e@	-1		// n N   ~   
-32	OEM_COMMA	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
-33	OEM_PERIOD	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
+32	OEM_PERIOD	0	002e	003f	-1	-1	00bf	-1		// . ?   ¿   
+33	OEM_COMMA	0	002c	0021	-1	-1	00a1	002c@		// , !   ¡ , 
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	202f	00a0		//         


### PR DESCRIPTION
This PR attempts to fix #72 by moving the virtual key codes associated with several physical keys.

- The VK_OEM_COMMA and VK_OEM_PERIOD are switched.
- The VK_OEM_PLUS goes to where VK_OEM_1 was, corresponding to <kbd>+</kbd>.
- The VK_OEM_MINUS is added where VK_OEM_6 was, corresponding to <kbd>-</kbd>.
- The VK_OEM_6 goes to where OEM_PLUS was, corresponding to <kbd>^</kbd>.
 
Please, note that the original AZERTY layout did not generate VK_OEM_MINUS.
Conversely, the new AZERTY-NF layout no longer generates VK_OEM_1.