### PR TITLE
Using the dot as a decimal separator from the numeric pad.

### DIFF
--- a/KBFRZ71.klc
+++ b/KBFRZ71.klc
@@ -78,7 +78,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	00a0	202f		//          
-53	DECIMAL		0	002c	002c	-1	-1	-1	-1		// , , 
+53	DECIMAL		0	002e	002e	-1	-1	-1	-1		// . . 
 
 // The following three keys are specifically set last in the layout
 // to prevent the Win32 VkKeyScanEx function to report an incorrect
@@ -817,7 +817,6 @@ DEADKEY 02d9
 00a4	02d9	// ¤ -> ˙
 00b5	02d9	// µ -> ˙
 00a0	02d9	//   -> ˙
-2003	02d9	//   -> ˙
 202f	02d9	//   -> ˙
 0020	02d9	//   -> ˙
 

--- a/KBFRZ71N.klc
+++ b/KBFRZ71N.klc
@@ -84,7 +84,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	00a0	202f		//          
-53	DECIMAL		0	002c	002c	-1	-1	-1	-1		// , , 
+53	DECIMAL		0	002e	002e	-1	-1	-1	-1		// . . 
 
 // The following three keys are specifically set last in the layout
 // to prevent the Win32 VkKeyScanEx function to report an incorrect

--- a/automation/KBFRZ71_base.inc
+++ b/automation/KBFRZ71_base.inc
@@ -32,7 +32,7 @@
 34	OEM_2		0	003a	2026	-1	-1	00b7	-1		// : …   ·   
 35	OEM_8		0	003b	003d	-1	-1	2243	2260		// ; =   ≃ ≠ 
 39	SPACE		0	0020	0020	2003	-1	00a0	202f		//          
-53	DECIMAL		0	002c	002c	-1	-1	-1	-1		// , , 
+53	DECIMAL		0	002e	002e	-1	-1	-1	-1		// . . 
 
 // The following three keys are specifically set last in the layout
 // to prevent the Win32 VkKeyScanEx function to report an incorrect


### PR DESCRIPTION
This is a nonstandard - unofficial - build of the layout using the dot character as a decimal separator from the numeric keypad.